### PR TITLE
[Merge] retrofit을 사용한 API 받아오기 및 MVVM Layer(Data, Domain, Ui) 구성

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools" >
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
 
@@ -13,13 +13,16 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Matchingmanager"
-        tools:targetApi="31" >
+        tools:targetApi="31">
+        <activity
+            android:name=".ui.home.arena.ArenaActivity"
+            android:exported="false" />
         <activity
             android:name=".ui.signin.SignInActivity"
             android:exported="false" />
         <activity
-            android:name=".ui.main.MainActivity"
-            android:exported="true" >
+            android:name=".ui.MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/example/matching_manager/data/model/ArenaResponse.kt
+++ b/app/src/main/java/com/example/matching_manager/data/model/ArenaResponse.kt
@@ -1,0 +1,49 @@
+package com.example.matching_manager.data.model
+
+import com.google.gson.annotations.SerializedName
+
+data class ArenaResponse(
+    @SerializedName("meta") val meta: MetaResponse?,
+    @SerializedName("documents") val documents: DocumentsResponse?
+)
+
+data class MetaResponse(
+
+    // 검색어에 검색된 문서 수
+    @SerializedName("total_count") val totalCount: Int?,
+    // total_count 중 노출 가능 문서 수 (최대: 45)
+    @SerializedName("pageable_count") val pageableCount: Int?,
+    // 현재 페이지가 마지막 페이지인지 여부 -> 값이 false면 다음 요청 시 page 값을 증가시켜 다음 페이지 요청 가능
+    @SerializedName("is_end") val isEnd: Boolean?,
+    // 질의어의 지역 및 키워드 분석 정보
+    @SerializedName("same_name") val sameName: SameNameResponse?
+
+)
+
+data class SameNameResponse(
+    // 질의어에서 인식된 지역의 리스트 ( 예: '중앙로 맛집' 에서 중앙로에 해당하는 지역 리스트 )
+    @SerializedName("region") val region: String?,
+    // 질의어에서 지역 정보를 제외한 키워드 ( 예: '중앙로 맛집' 에서 '맛집' )
+    @SerializedName("keyword") val keyword: String?,
+    // 인식된 지역 리스트 중, 현재 검색에 사용된 지역 정보
+    @SerializedName("selected_region") val selectedRegion: String?,
+)
+
+data class DocumentsResponse(
+    // 장소명, 업체명
+    @SerializedName("place_name") val placeName: String?,
+    // 전화 번호
+    @SerializedName("phone") val phone: String?,
+    // 전체 지번 주소
+    @SerializedName("address_name") val addressName: String?,
+    // 전체 도로명 주소
+    @SerializedName("road_address_name") val roadAddressName: String?,
+    // X 좌표값, 경위도인 경우 longitude (경도)
+    @SerializedName("x") val longitude: String?,
+    // Y 좌표값, 경위도인 경우 latitude(위도)
+    @SerializedName("y") val latitude: String?,
+    // 장소 상세페이지 URL
+    @SerializedName("place_url") val placeUrl: String?,
+    // 중심좌표까지의 거리 (단, x,y 파라미터를 준 경우에만 존재) (단위 meter)
+    @SerializedName("distance") val distance: String?,
+)

--- a/app/src/main/java/com/example/matching_manager/data/remote/ArenaRemoteDataSource.kt
+++ b/app/src/main/java/com/example/matching_manager/data/remote/ArenaRemoteDataSource.kt
@@ -1,0 +1,19 @@
+package com.example.matching_manager.data.remote
+
+import com.example.matching_manager.data.model.ArenaResponse
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface ArenaRemoteDataSource {
+
+    @GET("/v2/local/search/keyword")
+    suspend fun getArenaInfo(
+        @Query("query") query: String,
+        @Query("x") x: String,
+        @Query("y") y: Int,
+        @Query("radius") radius: Int,
+        @Query("page") page: Int,
+        @Query("size") size: Int,
+        @Query("sort") sort: Int,
+    ): ArenaResponse
+}

--- a/app/src/main/java/com/example/matching_manager/data/repository/ArenaRepositoryImpl.kt
+++ b/app/src/main/java/com/example/matching_manager/data/repository/ArenaRepositoryImpl.kt
@@ -1,0 +1,28 @@
+package com.example.matching_manager.data.repository
+
+import com.example.matching_manager.data.remote.ArenaRemoteDataSource
+import com.example.matching_manager.domain.model.ArenaEntity
+import com.example.matching_manager.domain.model.toArenaEntity
+import com.example.matching_manager.domain.repository.ArenaRepository
+
+class ArenaRepositoryImpl(
+    private val remoteDataSource: ArenaRemoteDataSource
+) : ArenaRepository {
+    override suspend fun getArenaInfo(
+        query: String,
+        x: String,
+        y: Int,
+        radius: Int,
+        page: Int,
+        size: Int,
+        sort: Int
+    ): ArenaEntity = remoteDataSource.getArenaInfo(
+        query,
+        x,
+        y,
+        radius,
+        page,
+        size,
+        sort
+    ).toArenaEntity()
+}

--- a/app/src/main/java/com/example/matching_manager/domain/model/ArenaEntity.kt
+++ b/app/src/main/java/com/example/matching_manager/domain/model/ArenaEntity.kt
@@ -1,0 +1,45 @@
+package com.example.matching_manager.domain.model
+
+data class ArenaEntity(
+    val meta: MetaEntity?,
+    val documents: DocumentsEntity?
+)
+
+data class MetaEntity(
+    // 검색어에 검색된 문서 수
+    val totalCount: Int?,
+    // total_count 중 노출 가능 문서 수 (최대: 45)
+    val pageableCount: Int?,
+    // 현재 페이지가 마지막 페이지인지 여부 -> 값이 false면 다음 요청 시 page 값을 증가시켜 다음 페이지 요청 가능
+    val isEnd: Boolean?,
+    // 질의어의 지역 및 키워드 분석 정보
+    val sameName: SameNameEntity?
+)
+
+data class SameNameEntity(
+    // 질의어에서 인식된 지역의 리스트 ( 예: '중앙로 맛집' 에서 중앙로에 해당하는 지역 리스트 )
+    val region: String?,
+    // 질의어에서 지역 정보를 제외한 키워드 ( 예: '중앙로 맛집' 에서 '맛집' )
+    val keyword: String?,
+    // 인식된 지역 리스트 중, 현재 검색에 사용된 지역 정보
+    val selectedRegion: String?,
+)
+
+data class DocumentsEntity(
+    // 장소명, 업체명
+    val placeName: String?,
+    // 전화 번호
+    val phone: String?,
+    // 전체 지번 주소
+    val addressName: String?,
+    // 전체 도로명 주소
+    val roadAddressName: String?,
+    // X 좌표값, 경위도인 경우 longitude (경도)
+    val longitude: String?,
+    // Y 좌표값, 경위도인 경우 latitude(위도)
+    val latitude: String?,
+    // 장소 상세페이지 URL
+    val placeUrl: String?,
+    // 중심좌표까지의 거리 (단, x,y 파라미터를 준 경우에만 존재) (단위 meter)
+    val distance: String?,
+)

--- a/app/src/main/java/com/example/matching_manager/domain/model/modelMapper.kt
+++ b/app/src/main/java/com/example/matching_manager/domain/model/modelMapper.kt
@@ -1,0 +1,35 @@
+package com.example.matching_manager.domain.model
+
+import com.example.matching_manager.data.model.ArenaResponse
+import com.example.matching_manager.data.model.DocumentsResponse
+import com.example.matching_manager.data.model.MetaResponse
+import com.example.matching_manager.data.model.SameNameResponse
+
+fun ArenaResponse.toArenaEntity() = ArenaEntity(
+    meta = meta?.toEntity(),
+    documents = documents?.toEntity()
+)
+
+fun MetaResponse.toEntity() = MetaEntity(
+    totalCount = totalCount,
+    pageableCount = pageableCount,
+    isEnd = isEnd,
+    sameName = sameName?.toEntity()
+)
+
+fun SameNameResponse.toEntity() = SameNameEntity(
+    region = region,
+    keyword = keyword,
+    selectedRegion = selectedRegion
+)
+
+fun DocumentsResponse.toEntity() = DocumentsEntity(
+    placeName = placeName,
+    phone = phone,
+    addressName = addressName,
+    roadAddressName = roadAddressName,
+    longitude = longitude,
+    latitude = latitude,
+    placeUrl = placeUrl,
+    distance = distance,
+)

--- a/app/src/main/java/com/example/matching_manager/domain/repository/ArenaRepository.kt
+++ b/app/src/main/java/com/example/matching_manager/domain/repository/ArenaRepository.kt
@@ -1,0 +1,16 @@
+package com.example.matching_manager.domain.repository
+
+import com.example.matching_manager.domain.model.ArenaEntity
+import retrofit2.http.Query
+
+interface ArenaRepository {
+    suspend fun getArenaInfo(
+        query: String,
+        x: String,
+        y: Int,
+        radius: Int,
+        page: Int,
+        size: Int,
+        sort: Int,
+    ): ArenaEntity
+}

--- a/app/src/main/java/com/example/matching_manager/domain/usecase/GetArenaInfoUseCase.kt
+++ b/app/src/main/java/com/example/matching_manager/domain/usecase/GetArenaInfoUseCase.kt
@@ -1,0 +1,26 @@
+package com.example.matching_manager.domain.usecase
+
+import com.example.matching_manager.domain.model.ArenaEntity
+import com.example.matching_manager.domain.repository.ArenaRepository
+
+class GetArenaInfoUseCase(
+    private val repository: ArenaRepository
+) {
+    suspend operator fun invoke(
+        query: String,
+        x: String,
+        y: Int,
+        radius: Int,
+        page: Int,
+        size: Int,
+        sort: Int,
+    ): ArenaEntity = repository.getArenaInfo(
+        query,
+        x,
+        y,
+        radius,
+        page,
+        size,
+        sort,
+    )
+}

--- a/app/src/main/java/com/example/matching_manager/retrofit/AuthorizationInterceptor.kt
+++ b/app/src/main/java/com/example/matching_manager/retrofit/AuthorizationInterceptor.kt
@@ -1,0 +1,19 @@
+package com.example.matching_manager.retrofit
+
+import com.example.matching_manager.R
+import okhttp3.Interceptor
+import okhttp3.Response
+
+class AuthorizationInterceptor : Interceptor {
+    // API 통신을 할 떄 마 catch를 해서 특정 행위를 하고싶을 때 Interceptor 사용
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val newRequest = chain.request().newBuilder()
+            .addHeader(
+                "Authorization",
+                "KakaoAK %s".format(
+                    R.string.kakao_api_key
+                )
+            ).build()
+        return chain.proceed(newRequest)
+    }
+}

--- a/app/src/main/java/com/example/matching_manager/retrofit/RetrofitClient.kt
+++ b/app/src/main/java/com/example/matching_manager/retrofit/RetrofitClient.kt
@@ -1,0 +1,36 @@
+package com.example.matching_manager.retrofit
+
+import com.example.matching_manager.data.remote.ArenaRemoteDataSource
+import com.google.gson.GsonBuilder
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+object RetrofitClient {
+
+    private const val  BASE_URL = "https://dapi.kakao.com"
+
+    private val okHttpClient by lazy {
+        OkHttpClient.Builder()
+            .addInterceptor(AuthorizationInterceptor())
+            .build()
+    }
+
+    private val retrofit by lazy {
+        Retrofit.Builder()
+            .baseUrl(BASE_URL)
+            .client(okHttpClient)
+            .addConverterFactory(GsonConverterFactory.create())
+            .addConverterFactory(GsonConverterFactory.create(getDateFormatGsonBuilder()))
+            .build()
+    }
+
+    private fun getDateFormatGsonBuilder() = GsonBuilder()
+        .setDateFormat("yyyy-MM-dd'T'HH:mm:ss")
+        .create()
+
+    val search: ArenaRemoteDataSource by lazy {
+        retrofit.create(ArenaRemoteDataSource::class.java)
+    }
+
+}

--- a/app/src/main/java/com/example/matching_manager/ui/home/arena/ArenaActivity.kt
+++ b/app/src/main/java/com/example/matching_manager/ui/home/arena/ArenaActivity.kt
@@ -1,0 +1,29 @@
+package com.example.matching_manager.ui.home.arena
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import androidx.activity.viewModels
+import com.example.matching_manager.databinding.ArenaActivityBinding
+
+class ArenaActivity : AppCompatActivity() {
+
+    private val binding by lazy { ArenaActivityBinding.inflate(layoutInflater) }
+
+    private val viewModel : ArenaViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(binding.root)
+
+        initView()
+        initModel()
+    }
+
+    private fun initView() = with(binding){
+    }
+
+    private fun initModel() = with(viewModel){
+
+
+    }
+}

--- a/app/src/main/java/com/example/matching_manager/ui/home/arena/ArenaModel.kt
+++ b/app/src/main/java/com/example/matching_manager/ui/home/arena/ArenaModel.kt
@@ -1,0 +1,11 @@
+package com.example.matching_manager.ui.home.arena
+
+data class ArenaModel(
+    private val placeName: String?,
+    private val phone: String?,
+    private val addressName: String?, // 지번 주소
+    private val roadAddressName: String?, // 도로명 주소
+    private val placeUrl: String?, // 장소 상세페이지 URL
+    // 중심좌표까지의 거리 (단, x,y 파라미터를 준 경우에만 존재) (단위 meter)
+    private val distance: String?,
+)

--- a/app/src/main/java/com/example/matching_manager/ui/home/arena/ArenaViewModel.kt
+++ b/app/src/main/java/com/example/matching_manager/ui/home/arena/ArenaViewModel.kt
@@ -1,0 +1,11 @@
+package com.example.matching_manager.ui.home.arena
+
+import androidx.lifecycle.ViewModel
+import com.example.matching_manager.domain.usecase.GetArenaInfoUseCase
+
+class ArenaViewModel(
+    private val arenaInfo: GetArenaInfoUseCase
+) : ViewModel(){
+
+
+}

--- a/app/src/main/java/com/example/matching_manager/ui/home/arena/ArenaViewModelFactory.kt
+++ b/app/src/main/java/com/example/matching_manager/ui/home/arena/ArenaViewModelFactory.kt
@@ -1,0 +1,25 @@
+package com.example.matching_manager.ui.home.arena
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.example.matching_manager.data.repository.ArenaRepositoryImpl
+import com.example.matching_manager.domain.repository.ArenaRepository
+import com.example.matching_manager.domain.usecase.GetArenaInfoUseCase
+import com.example.matching_manager.retrofit.RetrofitClient
+
+class ArenaViewModelFactory : ViewModelProvider.Factory{
+
+    private val repository: ArenaRepository = ArenaRepositoryImpl(
+        RetrofitClient.search
+    )
+
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(ArenaViewModel::class.java)) {
+            return ArenaViewModel(
+                GetArenaInfoUseCase(repository)
+            ) as T
+        } else {
+            throw IllegalArgumentException("Not found ViewModel class.")
+        }
+    }
+}

--- a/app/src/main/res/layout/arena_activity.xml
+++ b/app/src/main/res/layout/arena_activity.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.home.arena.ArenaActivity">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/kakao_api_key.xml
+++ b/app/src/main/res/values/kakao_api_key.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="kakao_api_key">1b17dcbddee95856256ea59c9bdfa8ad</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,4 @@
 
 
 
-
-
 </resources>


### PR DESCRIPTION
- retrofit을 사용한 API 받아오기
- MVVM 패턴을 위한 DataLayer 구성(Repository, Datasource)
- 추후 추가 구현 중간 분리점을 위한 DomainLayer 구성 (Usecase, Entity 등) + Repository facade 패턴
- Response -> Entitiy Mapping Class 추가
- Api 키 분리
- 비즈니스로직을 분리하기 위한 ViewModel 구현
- useCase 주입을 위한 Factory 추가
.close #12 